### PR TITLE
adding headers and clean warnings

### DIFF
--- a/src/include/opensocdebug.h
+++ b/src/include/opensocdebug.h
@@ -31,6 +31,8 @@
 #include <stdarg.h>
 #include <inttypes.h>
 #include <string.h>
+#include <stdlib.h>
+#include <stdio.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/system-info.c
+++ b/src/system-info.c
@@ -168,9 +168,9 @@ int osd_print_module_info(struct osd_context *ctx, uint16_t addr,
             fprintf(fh, "%sdata width: %d, ", indentstring,
                     mem->data_width);
             fprintf(fh, "address width: %d\n", mem->addr_width);
-            fprintf(fh, "%sbase address: 0x%016x, ", indentstring,
+            fprintf(fh, "%sbase address: 0x%016lx, ", indentstring,
                     mem->base_addr);
-            fprintf(fh, "memory size: %d Bytes\n", mem->size);
+            fprintf(fh, "memory size: %ld Bytes\n", mem->size);
             break;
         default:
             break;

--- a/src/tools/cli/cli.c
+++ b/src/tools/cli/cli.c
@@ -3,6 +3,7 @@
 #include <getopt.h>
 #include <readline/readline.h>
 #include <readline/history.h>
+#include "cli.h"
 
 int main(int argc, char* argv[]) {
     struct osd_context *ctx;


### PR DESCRIPTION
Compiler on my machine warns exit, memory_test, FILE, etc not declared.
Also the 64-bit printf warnings.
Still there is a warning related to accept(_,_,size_t *) in daemon.c
Compiler says size_t \* is not the expected type.
